### PR TITLE
Simple but not ideal fix for remove sides in ElementSubdomainModifier

### DIFF
--- a/framework/src/userobject/ElementSubdomainModifier.C
+++ b/framework/src/userobject/ElementSubdomainModifier.C
@@ -181,18 +181,19 @@ ElementSubdomainModifier::updateBoundaryInfo(MooseMesh & mesh,
     for (auto side : elem->side_index_range())
     {
       const Elem * neighbor = elem->neighbor_ptr(side);
+
       if (neighbor && neighbor != libMesh::remote_elem)
       {
-        // If the neighbor has a different subdomain ID, then this side should be added to
-        // the moving boundary
-        if (neighbor->subdomain_id() != elem->subdomain_id())
-          bnd_info.add_side(elem, side, _moving_boundary_id);
-        // Otherwise remove this side and the neighbor side from the boundary.
-        else
+        // Add all the sides to the boundary first and remove excessive sides later
+        bnd_info.add_side(elem, side, _moving_boundary_id);
+        // If this element and neighbor element are in the same subdomain, remove this side and the
+        // neighbor side from the boundary.
+        if (neighbor->subdomain_id() == elem->subdomain_id())
         {
-          bnd_info.remove_side(elem, side);
+          bnd_info.remove_side(elem, side, _moving_boundary_id);
           unsigned int neighbor_side = neighbor->which_neighbor_am_i(elem);
-          bnd_info.remove_side(neighbor, neighbor_side);
+          // nothing happens if the neighbor side does not exist in the subdomain
+          bnd_info.remove_side(neighbor, neighbor_side, _moving_boundary_id);
           if (neighbor->processor_id() != this->processor_id())
             ghost_sides_to_remove[neighbor->processor_id()].emplace_back(neighbor->id(),
                                                                          neighbor_side);

--- a/test/tests/userobjects/element_subdomain_modifier/adaptivity.i
+++ b/test/tests/userobjects/element_subdomain_modifier/adaptivity.i
@@ -1,0 +1,99 @@
+[Problem]
+  solve = false
+[]
+
+[Mesh]
+  [gen]
+    type = GeneratedMeshGenerator
+    dim = 2
+    xmin = -1
+    xmax = 1
+    ymin = -1
+    ymax = 1
+    nx = 16
+    ny = 16
+  []
+  [left]
+    type = SubdomainBoundingBoxGenerator
+    input = 'gen'
+    block_id = 1
+    bottom_left = '-1 -1 0'
+    top_right = '0 1 1'
+  []
+  [right]
+    type = SubdomainBoundingBoxGenerator
+    input = 'left'
+    block_id = 2
+    bottom_left = '0 -1 0'
+    top_right = '1 1 1'
+  []
+  [moving_boundary]
+    type = SideSetsAroundSubdomainGenerator
+    input = 'right'
+    block = 1
+    new_boundary = 'moving_boundary'
+    normal = '1 0 0'
+  []
+[]
+
+[UserObjects]
+  [moving_circle]
+    type = CoupledVarThresholdElementSubdomainModifier
+    coupled_var = 'phi'
+    block = 2
+    criterion_type = ABOVE
+    threshold = 0.5
+    subdomain_id = 1
+    moving_boundary_name = moving_boundary
+    execute_on = 'TIMESTEP_BEGIN'
+  []
+[]
+
+[Functions]
+  [moving_gauss]
+    type = ParsedFunction
+    value = 'exp(-((x+0.5-t)^2+(y)^2)/0.25)'
+  []
+[]
+
+[AuxVariables]
+  [phi]
+  []
+[]
+
+[AuxKernels]
+  [phi]
+    type = FunctionAux
+    variable = phi
+    function = moving_gauss
+    execute_on = 'INITIAL TIMESTEP_BEGIN TIMESTEP_END'
+  []
+[]
+
+[Adaptivity]
+  steps = 1
+  marker = marker
+  initial_marker = marker
+  max_h_level = 1
+  [Indicators/indicator]
+    type = GradientJumpIndicator
+    variable = phi
+  []
+  [Markers/marker]
+    type = ErrorFractionMarker
+    indicator = indicator
+    coarsen = 0.2
+    refine = 0.5
+    check_subdomain_consistent_for_coarsen = true
+  []
+[]
+
+[Executioner]
+  type = Transient
+  dt = 0.1
+  num_steps = 10
+[]
+
+[Outputs]
+  exodus = true
+[]


### PR DESCRIPTION
See comments in the code. 

When we have AMR with ElementSubdomainModifier, `remove_side()` triggers libmesh error since for child elements,  `_children_on_boundary false`

This fix avoids the error but is not ideal. 